### PR TITLE
[DEVELOPER-3322] Apache reverse proxy Drupal instance

### DIFF
--- a/_docker/environments/drupal-dev/apache/httpd-vhosts.conf
+++ b/_docker/environments/drupal-dev/apache/httpd-vhosts.conf
@@ -1,3 +1,10 @@
+<VirtualHost *:80>
+    ProxyPreserveHost On
+    ProxyPass / http://docker/
+    ProxyPassReverse / http://docker/
+    ServerName docker
+</VirtualHost>
+
 <VirtualHost *:9000>
     DocumentRoot "/usr/local/apache2/htdocs/docker"
     DirectoryIndex index.html

--- a/_docker/environments/drupal-dev/apache/httpd.conf
+++ b/_docker/environments/drupal-dev/apache/httpd.conf
@@ -49,6 +49,7 @@ ServerRoot "/usr/local/apache2"
 # prevent Apache from glomming onto all bound IP addresses.
 #
 #Listen 12.34.56.78:80
+Listen 80
 Listen 9000
 
 #
@@ -114,21 +115,21 @@ LoadModule headers_module modules/mod_headers.so
 LoadModule setenvif_module modules/mod_setenvif.so
 LoadModule version_module modules/mod_version.so
 #LoadModule remoteip_module modules/mod_remoteip.so
-#LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_module modules/mod_proxy.so
 #LoadModule proxy_connect_module modules/mod_proxy_connect.so
 #LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
-#LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
 #LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
 #LoadModule proxy_scgi_module modules/mod_proxy_scgi.so
 #LoadModule proxy_wstunnel_module modules/mod_proxy_wstunnel.so
-#LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
-#LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
+LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
 #LoadModule proxy_express_module modules/mod_proxy_express.so
 #LoadModule session_module modules/mod_session.so
 #LoadModule session_cookie_module modules/mod_session_cookie.so
 #LoadModule session_crypto_module modules/mod_session_crypto.so
 #LoadModule session_dbd_module modules/mod_session_dbd.so
-#LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
 #LoadModule ssl_module modules/mod_ssl.so
 #LoadModule lbmethod_byrequests_module modules/mod_lbmethod_byrequests.so
 #LoadModule lbmethod_bytraffic_module modules/mod_lbmethod_bytraffic.so

--- a/_docker/environments/drupal-dev/docker-compose.yml
+++ b/_docker/environments/drupal-dev/docker-compose.yml
@@ -87,7 +87,10 @@ services:
   apache:
    image: httpd:2.4.20
    command: "sh -c 'rm -f /usr/local/apache2/htdocs/index.html && httpd-foreground'"
+   links:
+    - drupal:docker
    expose:
+    - 80
     - 9000
    ports:
     - "9000:9000"


### PR DESCRIPTION
Makes Apache act as a reverse proxy onto the Drupal instance so that the tests can load resources from Drupal when running in an environment that has Drupal in "dev mode".