### PR TITLE
[DEVELOPER-3322] Allow configuration of logout URL for Drupal testss

### DIFF
--- a/javascripts/drupal-namespace.js
+++ b/javascripts/drupal-namespace.js
@@ -127,6 +127,7 @@ app.ssoConfig.auth_url = drupalSettings.rhd.keycloak.authUrl;
 var homeLink = document.getElementById('home-link')
 var confirmationPage = homeLink != null && homeLink.attributes['href'].value.endsWith('.html') ? 'confirmation.html' : 'confirmation'
 app.ssoConfig.confirmation = confirmationPage == 'confirmation.html' ? homeLink.href.replace('index.html',confirmationPage) : homeLink.href + confirmationPage
+app.ssoConfig.logout_url = homeLink.attributes['href']
 
 app.projects = {};
 app.projects.defaultImage = "/images/design/projects/default_200x150.png";

--- a/javascripts/namespace.js
+++ b/javascripts/namespace.js
@@ -100,6 +100,7 @@ app.ssoConfig = {};
 app.ssoConfig.account_url = '#{site.keycloak_account_url}';
 app.ssoConfig.auth_url = '#{site.keycloak_auth_url}';
 app.ssoConfig.confirmation = '#{site.base_url}/confirmation';
+app.ssoConfig.logout_url = '#{site.base_url}'
 
 app.projects = {};
 app.projects.defaultImage = "#{cdn( site.base_url + '/images/design/projects/default_200x150.png')}";

--- a/javascripts/sso.js
+++ b/javascripts/sso.js
@@ -15,7 +15,7 @@ app.sso = function () {
                 // once the promise comes back, listen for a click on logout
                 $('a.logout').on('click',function(e) {
                     e.preventDefault();
-                    keycloak.logout({"redirectUri":app.baseUrl});
+                    keycloak.logout({"redirectUri":app.ssoConfig.logout_url});
                 });
 
             }).error(clearTokens);


### PR DESCRIPTION
This PR adds the ability to configure the logout url as a property. This means it can be worked out differently depending on the environment. We need to add the property because in the Drupal export in a PR environment, app.baseURL is not the correct URL to re-direct someone to!