### PR TITLE
Re-order Dockerfile commands to install PhantomJS

### DIFF
--- a/_cucumber/Dockerfile
+++ b/_cucumber/Dockerfile
@@ -1,16 +1,16 @@
 FROM ruby:2.1.10
 MAINTAINER rblake@redhat.com, ihamilto@redhat.com
-RUN groupadd -g 1000 testing
-RUN useradd -g testing -m -s /bin/bash -u 1000 testing
-USER testing
-WORKDIR /home/testing
 
-USER root
 RUN mkdir /tmp/phantomjs \
     && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
            | tar -xj --strip-components=1 -C /tmp/phantomjs \
     && mv /tmp/phantomjs/bin/phantomjs /usr/bin \
     && rm -rf /tmp/phantomjs
+
+RUN groupadd -g 1000 testing
+RUN useradd -g testing -m -s /bin/bash -u 1000 testing
+USER testing
+WORKDIR /home/testing
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
@RubyGemTSL Can you try this approach. This still installs the PhantomJS driver as root, but we then create and user the `testing` user thereafter.

cheers,

Rob